### PR TITLE
fixed absolute asset links

### DIFF
--- a/Web/index.html
+++ b/Web/index.html
@@ -5,7 +5,7 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
 		<!-- Better support for mobile browsers -->
 		<title>Pizza Shop - Home</title>
-		<link rel="icon" href="/Assets/Logo.png" />
+		<link rel="icon" href="../Assets/Logo.png" />
 		<link href="CSS/index.css" rel="stylesheet" />
 	</head>
 
@@ -38,7 +38,7 @@
 
 		<!-- Top left logo -->
 		<div id="logo">
-			<img src="/Assets/Logo.png" alt="Logo" width="100vh" />
+			<img src="../Assets/Logo.png" alt="Logo" width="100vh" />
 		</div>
 
 		<!-- Title -->
@@ -51,8 +51,8 @@
 
 			<!-- History -->
 			<div class="box">
-				<a href="History.html">
-					<img src="/Assets/SVGs/History.svg" alt="Order history icon" />
+				<a href="history.html">
+					<img src="../Assets/SVGs/History.svg" alt="Order history icon" />
 					<h2>ORDER HISTORY</h2>
 				</a>
 			</div>
@@ -60,15 +60,15 @@
 			<!-- Delivery -->
 			<div class="box">
 				<a href="Delivery.html">
-					<img src="/Assets/SVGs/Delivery.svg" alt="Delivery icon" />
+					<img src="../Assets/SVGs/Delivery.svg" alt="Delivery icon" />
 					<h2>DELIVERY</h2>
 				</a>
 			</div>
 
 			<!-- Pick up -->
 			<div class="box">
-				<a href="Pickup.html">
-					<img src="/Assets/SVGs/Pick Up.svg" alt="Pick up icon" />
+				<a href="pickup.html">
+					<img src="../Assets/SVGs/Pick Up.svg" alt="Pick up icon" />
 					<h2>PICK UP</h2>
 				</a>
 			</div>
@@ -77,11 +77,11 @@
 		<!-- Contact -->
 		<div id="contact">
 			<div>
-				<img src="/Assets/SVGs/Phone.svg" alt="Phone icon" />
+				<img src="../Assets/SVGs/Phone.svg" alt="Phone icon" />
 				<h3>131 000</h3>
 			</div>
 			<div>
-				<img src="/Assets/SVGs/Mail.svg" alt="Mail icon" />
+				<img src="../Assets/SVGs/Mail.svg" alt="Mail icon" />
 				<h3>support@pizza.xyz</h3>
 			</div>
 		</div>


### PR DESCRIPTION
the links to the assets were using absolute links (e.g. "/Assets/image.png") this works when hosting locally because the root of the domain is you project, but when hosting on github pages it is on a subdirectory (minkdang.github.io/12A1-PizzaApp/Web/index.html) so when trying to access /Assets it tries to get "minkdang.github.io"/Assets rather than "minkdang.github.io/12A1-PizzaApp/Assets"
Instead use relative links "../Assets/image.png"